### PR TITLE
Clean up record metadata fields, release dates, record deletions

### DIFF
--- a/src/clinvar_combiner/core.clj
+++ b/src/clinvar_combiner/core.clj
@@ -180,7 +180,7 @@
                       (log/infof "Received %d messages to flush" (count scvs-to-flush))
                       (doseq [clinical-assertion scvs-to-flush]
                         (let [built-clinical-assertion (sink/build-clinical-assertion clinical-assertion)
-                              built-clinical-assertion (sink/post-process-built-scv built-clinical-assertion)
+                              built-clinical-assertion (sink/post-process-built-clinical-assertion built-clinical-assertion)
                               built-clinical-assertion-json (json/generate-string built-clinical-assertion)]
                           (assert (not (nil? (:id built-clinical-assertion)))
                                   (str "assertion :id cannot be nil: " built-clinical-assertion-json))

--- a/src/clinvar_streams/stream_utils.clj
+++ b/src/clinvar_streams/stream_utils.clj
@@ -55,3 +55,7 @@
               (recur (concat msgs batch)
                      (+ c (count batch)))
               )))))))
+; TODO
+(defn topic-exists? [topic-name]
+  "TODO"
+  (let [consumer ()]))


### PR DESCRIPTION
This pull request will contain a number of semi-related changes related to record metadata coherence and cleanup.

Includes #4

- remove internal metadata fields from assertion record and all sub-records, including release dates from sub-records
- set assertion release date to max of its own and all sub-records
- ensure deleted sub-records are not included in combined assertion