### PR TITLE
Update taoensso dependencies to work around conflicts.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,28 +5,27 @@
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/core.async "1.2.603"]
-                 [org.clojure/tools.namespace "1.1.0"]
                  [org.clojure/java.jdbc "0.7.11"]
                  [org.clojure/tools.cli "1.0.206"]
-                 [io.pedestal/pedestal.service "0.5.7"]
-                 [io.pedestal/pedestal.route "0.5.7"]
-                 [io.pedestal/pedestal.jetty "0.5.7"]
-                 [org.slf4j/slf4j-simple "1.7.28"]
-                 [mount "0.1.16"]
-                 [cli-matic "0.4.3"]
-                 [cheshire "5.10.0"]
-                 [mount/mount "0.1.16"]
-                 [clj-commons/fs "1.5.2"]
-                 [fundingcircle/jackdaw "0.7.4"]
-                 [com.google.cloud/google-cloud-storage "1.115.0"]
-                 ; timbre and nippy versions here have some conflicts
-                 [com.taoensso/timbre "4.10.0"
-                  :exclusions [com.taoensso/encore]]
-                 [com.taoensso/nippy "3.1.1"]
-                 [c3p0/c3p0 "0.9.1.2"]
-                 [digest/digest "1.4.10"]
-                 [nrepl "0.8.3"]
+                 [org.clojure/tools.namespace "1.1.0"]
                  [org.postgresql/postgresql "42.2.16"]
+                 [c3p0/c3p0 "0.9.1.2"]
+                 [cheshire "5.10.0"]
+                 [cli-matic "0.4.3"]
+                 [clj-commons/fs "1.5.2"]
+                 [com.google.cloud/google-cloud-storage "1.115.0"]
+                 [com.taoensso/encore "3.24.0"]
+                 [com.taoensso/nippy "3.2.0"]
+                 [com.taoensso/timbre "5.2.1"]
+                 [digest/digest "1.4.10"]
+                 [fundingcircle/jackdaw "0.7.4"]
+                 [io.pedestal/pedestal.jetty "0.5.7"]
+                 [io.pedestal/pedestal.route "0.5.7"]
+                 [io.pedestal/pedestal.service "0.5.7"]
+                 [mount "0.1.16"]
+                 [mount/mount "0.1.16"]
+                 [nrepl "0.8.3"]
+                 [org.slf4j/slf4j-simple "1.7.28"]
                  [org.xerial/sqlite-jdbc "3.32.3.2"]]
   :repl-options {:init-ns clinvar-raw.deduplicator
                  :caught clojure.repl/pst}
@@ -36,10 +35,12 @@
   :resource-paths ["resources"]
   :target-path "target/%s"
   :auto-clean false
-  :profiles {;:run-with-repl {:main clinvar-streams.core-repl
-             ;            :repl-options {:init-ns clinvar-streams.core-repl}}
-             :uberjar {:uberjar-name "clinvar-streams.jar"
-                       :aot [clinvar-streams.core]}
-             :testdata {:main clinvar-raw.generate-local-topic
-                        ;:aot [#"clinvar-raw.*"]
-                        :repl-options {:init-ns clinvar-raw.generate-local-topic}}})
+  :profiles
+  {#_#_
+   :run-with-repl {:main clinvar-streams.core-repl
+                   :repl-options {:init-ns clinvar-streams.core-repl}}
+   :uberjar {:uberjar-name "clinvar-streams.jar"
+             :aot [clinvar-streams.core]}
+   :testdata {:main clinvar-raw.generate-local-topic
+                                        ;:aot [#"clinvar-raw.*"]
+              :repl-options {:init-ns clinvar-raw.generate-local-topic}}})

--- a/src/clinvar_raw/stream.clj
+++ b/src/clinvar_raw/stream.clj
@@ -6,11 +6,10 @@
             [jackdaw.client :as jc]
             [jackdaw.data :as jd]
             [taoensso.timbre :as log])
-  (:import (com.google.cloud.storage BlobId StorageOptions)
-           com.google.cloud.storage.Blob$BlobSourceOption
-           java.io.BufferedReader
-           java.nio.channels.Channels
-           (java.time Duration)))
+  (:import [com.google.cloud.storage Blob$BlobSourceOption BlobId StorageOptions]
+           [java.io BufferedReader]
+           [java.nio.channels Channels]
+           [java.time Duration]))
 
 (def order-of-processing [{:type "gene"}
                           {:type "variation" :filter {:field :subclass_type :value "SimpleAllele"}}


### PR DESCRIPTION
These changes allow me to start a REPL in `clinvar-streams` and removes an `encore` exclusion.
Also sorted dependencies in deps.edn and cleaned up the `ns` form in `clinvar-raw.stream`.
The only important updates are:

```clojure
                 [com.taoensso/encore "3.24.0"]
                 [com.taoensso/nippy "3.2.0"]
                 [com.taoensso/timbre "5.2.1"]
```